### PR TITLE
nike-276/updated locomotion settings

### DIFF
--- a/source/humanoid_tasks/humanoid_tasks/locomotion/rsl_rl/config/t1/rsl_rl_cfg.py
+++ b/source/humanoid_tasks/humanoid_tasks/locomotion/rsl_rl/config/t1/rsl_rl_cfg.py
@@ -196,27 +196,6 @@ class ObservationsCfg:
     class PolicyCfg(ObsGroup):
         # observation terms (order preserved)
         """Observations for policy group."""
-        # height_scan = ObsTerm(
-        #     func=mdp.height_scan,
-        #     params={"sensor_cfg": SceneEntityCfg("height_scanner")},
-        #     noise=Unoise(n_min=-0.1, n_max=0.1),
-        #     clip=(-1.0, 1.0),
-        # )
-        # foot_force = ObsTerm(
-        #     func=humanoid_mdp.contact_sensor,
-        #     params={
-        #         "sensor_cfg": SceneEntityCfg("contact_forces", body_names="l[lr]6")
-        #     },
-        #     # noise=Unoise(n_min=-5, n_max=5),
-        # )
-        # ground_friction = ObsTerm(
-        #     func=humanoid_mdp.contact_friction,
-        #     params={"asset_cfg": SceneEntityCfg("robot", body_names="l[lr]6")},
-        #     noise=Unoise(n_min=-0.01, n_max=0.01),
-        # )
-        # base_lin_vel = ObsTerm(
-        #     func=mdp.base_lin_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
-        # )
         base_ang_vel = ObsTerm(
             func=mdp.base_ang_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
         )
@@ -293,9 +272,6 @@ class ObservationsCfg:
         velocity_commands = ObsTerm(
             func=mdp.generated_commands, params={"command_name": "base_velocity"}
         )
-        # frequency_command = ObsTerm(
-        #     func=mdp.generated_commands, params={"command_name": "frequency"}
-        # )
 
         def __post_init__(self) -> None:
             self.enable_corruption = True
@@ -312,7 +288,7 @@ class ObservationsCfg:
             params={
                 "sensor_cfg": SceneEntityCfg("contact_forces", body_names="l[lr]6")
             },
-            # noise=Unoise(n_min=-5, n_max=5),
+            noise=Unoise(n_min=-5, n_max=5),
         )
         ground_friction = ObsTerm(
             func=humanoid_mdp.contact_friction,
@@ -331,9 +307,6 @@ class ObservationsCfg:
         velocity_commands = ObsTerm(
             func=mdp.generated_commands, params={"command_name": "base_velocity"}
         )
-        # frequency_command = ObsTerm(
-        #     func=mdp.generated_commands, params={"command_name": "frequency"}
-        # )
         joint_pos = ObsTerm(
             func=mdp.joint_pos_rel,
             params={
@@ -415,8 +388,7 @@ class ObservationsCfg:
 class EventCfg:
     """Configuration for events."""
 
-    # NEW USING YAML
-    # i'm very confident this does nothing but gonna leave it here just in case
+    # confident this does nothing but gonna leave it here just in case
     base_external_force_torque = EventTerm(
         func=mdp.apply_external_force_torque,
         mode="reset",
@@ -441,17 +413,6 @@ class EventCfg:
         },
     )
 
-    # link_mass = EventTerm(
-    #     func=mdp.randomize_rigid_body_mass,
-    #     mode="startup",
-    #     params={
-    #         "asset_cfg": SceneEntityCfg("robot"),
-    #         "mass_distribution_params": (0.98, 1.02),
-    #         "operation": "scale",
-    #         "distribution": "uniform",
-    #     },
-    # )
-
     base_mass = EventTerm(
         func=mdp.randomize_rigid_body_mass,
         mode="startup",
@@ -463,18 +424,6 @@ class EventCfg:
             "distribution": "uniform",
         },
     )
-
-    # actuator_gains = EventTerm(
-    #     func=mdp.randomize_actuator_gains,
-    #     mode="startup",
-    #     params={
-    #         "asset_cfg": SceneEntityCfg("robot"),
-    #         "stiffness_distribution_params": (0.9, 1.1),
-    #         "damping_distribution_params": (1.0, 2.0),
-    #         "operation": "scale",
-    #         "distribution": "uniform",
-    #     },
-    # )
 
     # reset
     reset_base = EventTerm(
@@ -539,19 +488,7 @@ class RewardsCfg:
         weight=5.0,
         params={"std": 1.0, "asset_cfg": SceneEntityCfg("robot")},
     )
-    # air_time = RewTerm(
-    #     func=humanoid_mdp.air_time_reward_cmd_biped,
-    #     weight=5.0,
-    #     params={
-    #         "sensor_cfg": SceneEntityCfg(
-    #             "contact_forces",
-    #             body_names="l[lr]6",
-    #             # body_names=[".*_foot_link"]
-    #         )
-    #     },
-    # )
 
-    # NEW
     feet_air_time = RewTerm(
         func=locomotion_mdp.feet_air_time_positive_biped,
         weight=0.25,
@@ -597,7 +534,6 @@ class RewardsCfg:
             )
         },
     )
-    # END OF NEW
     foot_clearance = RewTerm(
         func=humanoid_mdp.foot_clearance_reward,
         weight=0.5,
@@ -626,10 +562,6 @@ class RewardsCfg:
             "max_error": 0.2,
         },
     )
-    # base_height = RewTerm(
-    #     func=humanoid_mdp.target_base_height, weight=1.0, params={"target_height": 0.68}
-    # )
-    # alive = RewTerm(func=mdp.is_alive, weight=5.0)
 
     # -- penalties
     angular_motion = RewTerm(
@@ -704,15 +636,6 @@ class RewardsCfg:
             "stand_still_scale": 10.0,
         },
     )
-    # TODO make in terms of body wrt to ground, not joint angle
-    # ankle_roll_joint_pos_penalty = RewTerm(
-    #     func=humanoid_mdp.joint_position_penalty,
-    #     weight=-1.0,
-    #     params={"asset_cfg": SceneEntityCfg(
-    #         "robot",
-    #         joint_names=["joint_l[lr]6"]
-    #     ), "stand_still_scale": 10.0},
-    # )
     joint_vel = RewTerm(
         func=humanoid_mdp.joint_velocity_penalty,
         weight=-1.0e-2,
@@ -735,16 +658,6 @@ class RewardsCfg:
             )
         },
     )
-    # ankle_joint_acc = RewTerm(
-    #     func=humanoid_mdp.joint_acceleration_penalty,
-    #     weight=-1.0e-3,
-    #     params={"asset_cfg": SceneEntityCfg("robot", joint_names=["joint_l[lr][56]"])},
-    # )
-    # arm_joint_acc = RewTerm(
-    #     func=humanoid_mdp.joint_acceleration_penalty,
-    #     weight=-1.0e-3,
-    #     params={"asset_cfg": SceneEntityCfg("robot", joint_names=["joint_a[lr].*"])},
-    # )
     joint_torques = RewTerm(
         func=humanoid_mdp.joint_torques_penalty,
         weight=-5.0e-4,
@@ -756,75 +669,6 @@ class RewardsCfg:
             )
         },
     )
-    # joint_arm_torques = RewTerm(
-    #     func=humanoid_mdp.joint_torques_penalty,
-    #     weight=-5.0e-3,
-    #     params={"asset_cfg": SceneEntityCfg(
-    #         "robot",
-    #         # joint_names=["joint_a[lr].*", "joint_waist"]
-    #         joint_names=[
-    #             ".*_Shoulder_Pitch",
-    #             ".*_Shoulder_Roll",
-    #             ".*_Elbow_Pitch",
-    #             ".*_Elbow_Yaw",
-    #             "Waist",
-    #         ]
-    #     )},
-    # )
-    # foot_orientation = RewTerm(
-    #     func=humanoid_mdp.foot_orientation,
-    #     weight=-15.0,
-    #     params={
-    #         "asset_cfg": SceneEntityCfg(
-    #             "robot",
-    #             body_names="l[lr]6",
-    #             # body_names=[".*_foot_link"]
-    #         )
-    #     },
-    # )
-    # foot_lateral_penalty = RewTerm(
-    #     func=humanoid_mdp.foot_lateral_penalty, weight=-15.0,
-    #     params={"asset_cfg": SceneEntityCfg(
-    #         "robot",
-    #         body_names="l[lr]6"
-    #         # body_names=[".*_foot_link"]
-    #     )}
-    # )
-    # feet_yaw_diff_penalty = RewTerm(
-    #     func=humanoid_mdp.feet_yaw_diff_penalty,
-    #     weight=-5.0,
-    #     params={
-    #         "asset_cfg": SceneEntityCfg(
-    #             "robot",
-    #             body_names="l[lr]6",
-    #             # body_names=[".*_foot_link"]
-    #         )
-    #     },
-    # )
-
-    # foot_distance = RewTerm(
-    #     func=humanoid_mdp.foot_distance,
-    #     weight=-10.0,
-    #     params={
-    #         "asset_cfg": SceneEntityCfg(
-    #             "robot",
-    #             body_names="l[lr]6",
-    #             # body_names=[".*_foot_link"]
-    #         ),
-    #         "min_dist": 0.3,
-    #     },
-    # )
-    # heel_toe_stepping_penalty = RewTerm(
-    #     func=humanoid_mdp.heel_toe_stepping_penalty, weight=-1.0,
-    #     params={
-    #         "asset_cfg": SceneEntityCfg("robot", body_names=["l[lr]6"]),
-    #         "sensor_cfg": SceneEntityCfg(
-    #             "contact_forces",
-    #             body_names="l[lr]6"
-    #             # body_names=[".*_foot_link"]
-    #         ),
-    #     }
-    # )
 
 
 @configclass
@@ -836,42 +680,6 @@ class TerminationsCfg:
         func=mdp.root_height_below_minimum,
         params={"minimum_height": 0.4, "asset_cfg": SceneEntityCfg("robot")},
     )
-    # non_foot_contact = DoneTerm(
-    #     func=mdp.illegal_contact,
-    #     params={"sensor_cfg": SceneEntityCfg(
-    #         "contact_forces",
-    #         # body_names="l[lr][1-5]"
-    #         body_names=[
-    #             "Hip_Pitch_.*",
-    #             "Hip_Roll_.*",
-    #             "Hip_Yaw_.*",
-    #             "Shank_.*",
-    #             "Ankle_Cross_.*"
-    #         ]
-    #     ), "threshold": 1.0},
-    # )
-    # left_foot_contact = DoneTerm(
-    #     func=humanoid_mdp.illegal_contact_filtered,
-    #     params={
-    #         "threshold": 1.0,
-    #         "sensor_cfg": SceneEntityCfg(
-    #             "left_foot",
-    #             body_names="ll6",
-    #             # body_names="left_foot_link"
-    #         ),
-    #     },
-    # )
-    # right_foot_contact = DoneTerm(
-    #     func=humanoid_mdp.illegal_contact_filtered,
-    #     params={
-    #         "threshold": 1.0,
-    #         "sensor_cfg": SceneEntityCfg(
-    #             "right_foot",
-    #             # body_names="lr6"
-    #             body_names="right_foot_link"
-    #         ),
-    #     }
-    # )
     terrain_out_of_bounds = DoneTerm(
         func=humanoid_mdp.terrain_out_of_bounds,
         params={"asset_cfg": SceneEntityCfg("robot"), "distance_buffer": 3.0},

--- a/source/humanoid_tasks/humanoid_tasks/locomotion/rsl_rl/config/t1/rsl_rl_cfg.py
+++ b/source/humanoid_tasks/humanoid_tasks/locomotion/rsl_rl/config/t1/rsl_rl_cfg.py
@@ -21,8 +21,6 @@ from isaaclab.utils.assets import (
     NVIDIA_NUCLEUS_DIR,
 )
 from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
-from isaaclab.utils.noise import AdditiveGaussianNoiseCfg as Gnoise
-from isaaclab.sensors import RayCasterCfg, patterns
 
 
 import isaaclab.envs.mdp as mdp
@@ -216,8 +214,12 @@ class ObservationsCfg:
         #     params={"asset_cfg": SceneEntityCfg("robot", body_names="l[lr]6")},
         #     noise=Unoise(n_min=-0.01, n_max=0.01),
         # )
-        base_lin_vel = ObsTerm(func=mdp.base_lin_vel, noise=Unoise(n_min=-0.1, n_max=0.1))
-        base_ang_vel = ObsTerm(func=mdp.base_ang_vel, noise=Unoise(n_min=-0.1, n_max=0.1))
+        base_lin_vel = ObsTerm(
+            func=mdp.base_lin_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
+        )
+        base_ang_vel = ObsTerm(
+            func=mdp.base_ang_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
+        )
         projected_gravity = ObsTerm(
             func=mdp.projected_gravity, noise=Unoise(n_min=-0.05, n_max=0.05)
         )
@@ -305,9 +307,15 @@ class ObservationsCfg:
         """Observations for policy group."""
 
         # observation terms (order preserved)
-        base_lin_vel = ObsTerm(func=mdp.base_lin_vel, noise=Unoise(n_min=-0.1, n_max=0.1))
-        base_ang_vel = ObsTerm(func=mdp.base_ang_vel, noise=Unoise(n_min=-0.1, n_max=0.1))
-        projected_gravity = ObsTerm(func=mdp.projected_gravity, noise=Unoise(n_min=-0.05, n_max=0.05))
+        base_lin_vel = ObsTerm(
+            func=mdp.base_lin_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
+        )
+        base_ang_vel = ObsTerm(
+            func=mdp.base_ang_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
+        )
+        projected_gravity = ObsTerm(
+            func=mdp.projected_gravity, noise=Unoise(n_min=-0.05, n_max=0.05)
+        )
         velocity_commands = ObsTerm(
             func=mdp.generated_commands, params={"command_name": "base_velocity"}
         )
@@ -406,8 +414,6 @@ class EventCfg:
             "torque_range": (-0.0, 0.0),
         },
     )
-
-
 
     # startup
     physics_material = EventTerm(
@@ -538,28 +544,28 @@ class RewardsCfg:
         func=locomotion_mdp.feet_air_time_positive_biped,
         weight=0.25,
         params={
-            "command_name" : "base_velocity",
-            "threshold" : 0.4,
+            "command_name": "base_velocity",
+            "threshold": 0.4,
             "sensor_cfg": SceneEntityCfg(
                 "contact_forces",
                 body_names="l[lr]6",
                 preserve_order=False,
-            )
-        }
+            ),
+        },
     )
     dof_pos_limits = RewTerm(
         func=mdp.joint_pos_limits,
         weight=-1.0,
         params={
             "asset_cfg": SceneEntityCfg("robot", joint_names="joint_l[lr]6"),
-        }
+        },
     )
     joint_deviation_hip = RewTerm(
         func=mdp.joint_deviation_l1,
         weight=-0.1,
         params={
             "asset_cfg": SceneEntityCfg("robot", joint_names=["joint_l[lr][1-3]"]),
-        }
+        },
     )
     joint_lateral_leg_pos = RewTerm(
         func=humanoid_mdp.joint_position_penalty,
@@ -567,7 +573,7 @@ class RewardsCfg:
         params={
             "asset_cfg": SceneEntityCfg("robot", joint_names=["joint_l[lr]2"]),
             "stand_still_scale": 10.0,
-        }
+        },
     )
     joint_lateral_leg_vel = RewTerm(
         func=humanoid_mdp.joint_velocity_penalty,
@@ -615,13 +621,10 @@ class RewardsCfg:
 
     # -- penalties
     angular_motion = RewTerm(
-        func=humanoid_mdp.angular_motion_penalty, 
+        func=humanoid_mdp.angular_motion_penalty,
         weight=-0.5,
     )
-    base_orientation = RewTerm(
-        func=humanoid_mdp.base_orientation_penalty, 
-        weight=-1.0
-    )
+    base_orientation = RewTerm(func=humanoid_mdp.base_orientation_penalty, weight=-1.0)
     foot_slip = RewTerm(
         func=humanoid_mdp.foot_slip_penalty,
         weight=-0.5,
@@ -640,7 +643,7 @@ class RewardsCfg:
         },
     )
     action_smoothness = RewTerm(
-        func=humanoid_mdp.action_smoothness_penalty, 
+        func=humanoid_mdp.action_smoothness_penalty,
         weight=-1.0,
     )
     air_time_variance = RewTerm(

--- a/source/humanoid_tasks/humanoid_tasks/locomotion/rsl_rl/config/t1/rsl_rl_cfg.py
+++ b/source/humanoid_tasks/humanoid_tasks/locomotion/rsl_rl/config/t1/rsl_rl_cfg.py
@@ -388,7 +388,6 @@ class ObservationsCfg:
 class EventCfg:
     """Configuration for events."""
 
-    # confident this does nothing but gonna leave it here just in case
     base_external_force_torque = EventTerm(
         func=mdp.apply_external_force_torque,
         mode="reset",

--- a/source/humanoid_tasks/humanoid_tasks/locomotion/rsl_rl/config/t1/rsl_rl_cfg.py
+++ b/source/humanoid_tasks/humanoid_tasks/locomotion/rsl_rl/config/t1/rsl_rl_cfg.py
@@ -214,9 +214,9 @@ class ObservationsCfg:
         #     params={"asset_cfg": SceneEntityCfg("robot", body_names="l[lr]6")},
         #     noise=Unoise(n_min=-0.01, n_max=0.01),
         # )
-        base_lin_vel = ObsTerm(
-            func=mdp.base_lin_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
-        )
+        # base_lin_vel = ObsTerm(
+        #     func=mdp.base_lin_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
+        # )
         base_ang_vel = ObsTerm(
             func=mdp.base_ang_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
         )
@@ -307,6 +307,18 @@ class ObservationsCfg:
         """Observations for policy group."""
 
         # observation terms (order preserved)
+        foot_force = ObsTerm(
+            func=humanoid_mdp.contact_sensor,
+            params={
+                "sensor_cfg": SceneEntityCfg("contact_forces", body_names="l[lr]6")
+            },
+            # noise=Unoise(n_min=-5, n_max=5),
+        )
+        ground_friction = ObsTerm(
+            func=humanoid_mdp.contact_friction,
+            params={"asset_cfg": SceneEntityCfg("robot", body_names="l[lr]6")},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        )
         base_lin_vel = ObsTerm(
             func=mdp.base_lin_vel, noise=Unoise(n_min=-0.1, n_max=0.1)
         )


### PR DESCRIPTION
### What changed and why:
- Implemented all of the rewards and weights from a previous project's YAML that had a successful walking policy.
- Roughly doubled training time, and re-trained policy had seemingly improved walking capabilities.
- Removed large amounts of commented dead code in rsl_rf_cfg.py for cleanliness.
- Disabled terrain curriculum.